### PR TITLE
Update create_installation_manifests.yaml

### DIFF
--- a/create_installation_manifests.yaml
+++ b/create_installation_manifests.yaml
@@ -35,6 +35,10 @@
   - name: Create installation manifests of new cluster
     command: openshift-install create manifests --dir={{ cluster_name }}
     
+  - name: Remove machines and machinesets
+    command: rm -f {{ cluster_name }}/openshift/99_openshift-cluster-api_master-machines-*.yaml {{ cluster_name }}/openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+    when: openshift_major_version == 4.5
+    
   - name: Set masters as unschedulable
     lineinfile:
       path: "{{ cluster_name }}/manifests/cluster-scheduler-02-config.yml"


### PR DESCRIPTION
Installation document for 4.5 mentions following:

"2. Remove the Kubernetes manifest files that define the control plane machines and compute machineSets:"

https://docs.openshift.com/container-platform/4.5/installing/installing_vsphere/installing-vsphere.html#installation-user-infra-generate-k8s-manifest-ignition_installing-vsphere

Issues caused by this:
4.4
https://access.redhat.com/solutions/5086271
4.5
https://access.redhat.com/solutions/5298231