### PR TITLE
Update network-utility.ign.j2

### DIFF
--- a/templates/network-utility.ign.j2
+++ b/templates/network-utility.ign.j2
@@ -6,7 +6,7 @@
         "timeouts": {
 
         },
-        "version": "2.1.0"
+        "version": "3.0.0"
     },
     "networkd": {
 


### PR DESCRIPTION
2.1 versiyonu artık yemiyor. 3.0.0 verince ayağa kalktı makineler